### PR TITLE
MacTex changed paths to binaries

### DIFF
--- a/racket-poppler/render-tex.rkt
+++ b/racket-poppler/render-tex.rkt
@@ -44,15 +44,15 @@
   (set! defaultdir
         (or defaultdir
             (case (system-type)
-              [(macosx) "/Library/TeX/texbin"]
+              [(macosx) "/usr/texbin"]
               [else     "/usr/bin"])))
   (cond [(find-executable-path name) => (λ (p) p)]
         [(find-executable-path (string-append name ".exe")) => (λ (p) p)]
         [else  (build-path defaultdir name)]))
 
 ;; Default paths
-(define latex-path (make-parameter (find-executable "latex" "/usr/bin")))
-(define dvipng-path (make-parameter (find-executable "dvipng" "/usr/bin")))
+(define latex-path (make-parameter (find-executable "latex")))
+(define dvipng-path (make-parameter (find-executable "dvipng")))
 (define cache-path (make-parameter (find-system-path 'temp-dir)))
 
 ;; Exceptions raised


### PR DESCRIPTION
MacTex-2015 changed paths to pdflatex, latex, and dvipng. (applications can no longer use /usr/bin)
This change works for me - I am running an updated mactex, on 10.10 - it should also work fine on 10.11.