### PR TITLE
don't depends on non-existant package

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -7,7 +7,6 @@
                "base" "pict"
                ("poppler-x86-64-macosx" #:platform "x86_64-macosx")
                ("poppler-i386-macosx"   #:platform "i386-macosx")
-               ("poppler-ppc-macosx"    #:platform "ppc-macosx")
                ("poppler-win32-x86-64"  #:platform "win32\\x86_64")
                ("poppler-win32-i386"    #:platform "win32\\i386")))
 


### PR DESCRIPTION
The dependency on the non-existent ppc native package breaks builds using `raco pkg install --all-platforms`